### PR TITLE
Dump Wii U boot0, vWii NG ID/signature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.vscode/
 build
 output
 *.elf

--- a/source/boot0.c
+++ b/source/boot0.c
@@ -17,7 +17,7 @@
 
 u16 boot0_read(void *dst, u16 offset, u16 size)
 {
-    if (!dst || offset >= BOOT0_SIZE || !size || (offset + size) > BOOT0_SIZE) return 0;
+    if (!dst || offset >= BOOT0_WIIU_SIZE || !size || (offset + size) > BOOT0_WIIU_SIZE) return 0;
 
     u8 *ptr = (u8*)dst;
     u8 val[BOOT0_BLK_SIZE] = {0};

--- a/source/boot0.h
+++ b/source/boot0.h
@@ -1,7 +1,8 @@
 #ifndef __BOOT0_H__
 #define __BOOT0_H__
 
-#define BOOT0_SIZE    0x1000
+#define BOOT0_SIZE      0x1000
+#define BOOT0_WIIU_SIZE 0x4000
 
 u16 boot0_read(void *dst, u16 offset, u16 size);
 

--- a/source/vwii_sram_otp.c
+++ b/source/vwii_sram_otp.c
@@ -1,0 +1,68 @@
+#include <ogc/machine/processor.h>
+#include <unistd.h>
+#include <string.h>
+
+#include "vwii_sram_otp.h"
+#include "tools.h"
+
+#define SRAM_OTP_MIRR   0xD407F00
+
+#define HW_SRNPROT      0xD800060
+#define SRAM_MASK       0x20
+#define OTP_BLK_SIZE    4
+
+u16 vwii_sram_otp_read(void *dst, u16 offset, u16 size)
+{
+    if (!dst || offset >= SRAM_OTP_SIZE || !size || (offset + size) > SRAM_OTP_SIZE) return 0;
+
+    u8 *ptr = (u8*)dst;
+    u8 val[OTP_BLK_SIZE] = {0};
+    u16 cur_offset = 0;
+    bool disable_sram_mirror = false;
+
+    // Calculate block offsets and sizes
+    u32 start_addr = (SRAM_OTP_MIRR + ALIGN_DOWN(offset, OTP_BLK_SIZE));
+    u8 start_addr_offset = (offset % OTP_BLK_SIZE);
+
+    u32 end_addr = (SRAM_OTP_MIRR + ALIGN_UP(offset + size, OTP_BLK_SIZE));
+    u8 end_addr_size = ((offset + size) % OTP_BLK_SIZE);
+
+    // Make sure the SRAM mirror is enabled (unlikely to be disabled, but let's play it safe)
+    if (!(read32(HW_SRNPROT) & SRAM_MASK))
+    {
+        // Enable SRAM mirror
+        mask32(HW_SRNPROT, 0, SRAM_MASK);
+        disable_sram_mirror = true;
+    }
+
+    for(u32 addr = start_addr; addr < end_addr; addr += OTP_BLK_SIZE)
+    {
+        if (cur_offset >= size) break;
+
+        // Read SRAM mirror (actually holds OTP data)
+        *((u32*)val) = read32(addr);
+
+        // Copy data to destination buffer
+        if (addr == start_addr && start_addr_offset != 0)
+        {
+            // Handle unaligned read at start address
+            memcpy(ptr + cur_offset, val + start_addr_offset, OTP_BLK_SIZE - start_addr_offset);
+            cur_offset += (OTP_BLK_SIZE - start_addr_offset);
+        } else
+        if (addr >= (end_addr - OTP_BLK_SIZE) && end_addr_size != 0)
+        {
+            // Handle unaligned read at end address
+            memcpy(ptr + cur_offset, val, end_addr_size);
+            cur_offset += end_addr_size;
+        } else {
+            // Normal read
+            memcpy(ptr + cur_offset, val, OTP_BLK_SIZE);
+            cur_offset += OTP_BLK_SIZE;
+        }
+    }
+
+    // Disable SRAM mirror, if needed
+    if (disable_sram_mirror) mask32(HW_SRNPROT, SRAM_MASK, 0);
+
+    return cur_offset;
+}

--- a/source/vwii_sram_otp.h
+++ b/source/vwii_sram_otp.h
@@ -1,0 +1,18 @@
+#ifndef __VWII_SRAM_OTP_H__
+#define __VWII_SRAM_OTP_H__
+
+#define SRAM_OTP_SIZE 0x80
+
+typedef struct {
+    u32 ms_id; // 0x00000002
+    u32 ca_id; // 0x00000001
+    u32 ng_key_id;
+    u8 ng_sig[60];
+    /* locked out, seemingly */
+    u8 korean_key[16];
+    u8 nss_device_cert[32];
+} vwii_sram_otp;
+
+u16 vwii_sram_otp_read(void *dst, u16 offset, u16 size);
+
+#endif /* __VWII_SRAM_OTP_H__ */


### PR DESCRIPTION
This will dump the full Wii U boot0 (16KB, rather than 4KB) when running under vWii, as well as fetch the OTP bank 6 data from the end of IOS's SRAM.

(I haven't yet verified if the key + signature retrieved from SRAM are in fact correct... they *should* be, though.)